### PR TITLE
Expose ability to override dependencies of rules_proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+.ijwb

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -19,16 +19,22 @@ load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
 
-def rules_proto_dependencies():
+def rules_proto_dependencies(
+        override_dependencies = {},
+        override_maven_dependencies = {}
+        ):
     """An utility method to load all dependencies of `rules_proto`.
 
     Loads the remote repositories used by default in Bazel.
     """
 
-    for name in dependencies:
-        maybe(http_archive, name, **dependencies[name])
-    for name in maven_dependencies:
-        maybe(java_import_external, name, **maven_dependencies[name])
+    _dependencies = dict(dependencies.items() + override_dependencies.items())
+    _maven_dependencies = dict(maven_dependencies.items() + override_maven_dependencies.items())
+
+    for name in _dependencies:
+        maybe(http_archive, name, **_dependencies[name])
+    for name in _maven_dependencies:
+        maybe(java_import_external, name, **_maven_dependencies[name])
     protobuf_workspace(name = "com_google_protobuf")
 
 def rules_proto_toolchains():


### PR DESCRIPTION
Problem
======

We generally need to override url locations of dependencies used by `rules_proto`.  

Solution
======

Provide overriding of `dependencies` and `maven_dependencies` in `rules_proto_dependencies`. 